### PR TITLE
Add in-page error reporting + private helpful-vote to posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Это репозиторий [блога](https://mouseml.github.io/blog) с постами по видео на канале [мыш](https://www.youtube.com/channel/UCscWjyvPudzdIaGCCtEL3nw).
 
-Я мог сделать ошибки в постах, поэтому буду рад, если вы поможете их найти. Об ошибках можно сообщить в [Telegram](https://t.me/ml_mouse), через [GitHub Issue](https://github.com/mouseml/blog/issues) или [Pull Request](https://github.com/mouseml/blog/pulls).
+Я мог сделать ошибки в постах, поэтому буду рад, если вы поможете их найти. Проще всего — кнопкой «Нашли ошибку?» в конце любого поста (или выделите текст с ошибкой). Также можно написать в [Telegram](https://t.me/ml_mouse), открыть [GitHub Issue](https://github.com/mouseml/blog/issues) или [Pull Request](https://github.com/mouseml/blog/pulls).
 
 Я слежу за вами через Google Analytics. Так я могу узнать, какие посты вы чаще читаете и сколько времени проводите на странице. Это помогает мне делать посты полезнее.
 

--- a/src/components/HelpfulVote.astro
+++ b/src/components/HelpfulVote.astro
@@ -40,9 +40,6 @@ const { postId } = Astro.props;
     display: flex;
     align-items: center;
     gap: 16px;
-    margin-top: 40px;
-    padding-top: 22px;
-    border-top: 1px solid var(--line);
   }
   .helpful-q {
     font-size: 11px;

--- a/src/components/HelpfulVote.astro
+++ b/src/components/HelpfulVote.astro
@@ -29,7 +29,11 @@ const { postId } = Astro.props;
         // gtag is prod-only and may be ad-blocked → optional call, silent no-op otherwise.
         const w = window as unknown as { gtag?: (...args: unknown[]) => void };
         w.gtag?.('event', 'helpful', { post_id: post, rating });
-        root.innerHTML = '<span class="helpful-q mono">Спасибо за отзыв!</span>';
+        // Retitle the existing (scoped-styled) label and drop the buttons — a fresh
+        // span via innerHTML would lose the component's scoped 11px styling.
+        const label = root.querySelector<HTMLElement>('.helpful-q');
+        if (label) label.textContent = 'Спасибо за отзыв!';
+        root.querySelector('.helpful-actions')?.remove();
       });
     });
   }

--- a/src/components/HelpfulVote.astro
+++ b/src/components/HelpfulVote.astro
@@ -1,0 +1,70 @@
+---
+// Private "was this helpful?" signal. Clicking Да/Нет fires a Google Analytics
+// event (gtag is already loaded in Base.astro, prod-only) with the post id +
+// yes/no — *no counter is rendered*, so it can't suffer the empty-counter /
+// ghost-town problem: it's feedback for the author, not social proof for the
+// reader. Degrades silently when gtag is absent (dev, or blocked by an
+// ad-blocker). Kept out of the Pagefind index via data-pagefind-ignore.
+interface Props {
+  postId: string;
+}
+const { postId } = Astro.props;
+---
+
+<div class="helpful" data-pagefind-ignore data-post={postId}>
+  <span class="helpful-q mono">Полезно?</span>
+  <div class="helpful-actions">
+    <button class="helpful-btn mono" type="button" data-value="yes">Да</button>
+    <button class="helpful-btn mono" type="button" data-value="no">Нет</button>
+  </div>
+</div>
+
+<script>
+  const root = document.querySelector<HTMLElement>('.helpful');
+  if (root) {
+    const post = root.dataset.post || '';
+    root.querySelectorAll<HTMLButtonElement>('.helpful-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const rating = btn.dataset.value || '';
+        // gtag is prod-only and may be ad-blocked → optional call, silent no-op otherwise.
+        const w = window as unknown as { gtag?: (...args: unknown[]) => void };
+        w.gtag?.('event', 'helpful', { post_id: post, rating });
+        root.innerHTML = '<span class="helpful-q mono">Спасибо за отзыв!</span>';
+      });
+    });
+  }
+</script>
+
+<style>
+  .helpful {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-top: 40px;
+    padding-top: 22px;
+    border-top: 1px solid var(--line);
+  }
+  .helpful-q {
+    font-size: 11px;
+    color: var(--fg-faint);
+  }
+  .helpful-actions {
+    display: flex;
+    gap: 10px;
+  }
+  .helpful-btn {
+    padding: 7px 16px;
+    font-size: 11px;
+    border: 1px solid var(--line);
+    border-radius: 0;
+    background: none;
+    color: var(--fg-dim);
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+  }
+  .helpful-btn:hover {
+    color: #fff;
+    border-color: var(--line-strong);
+    background: rgba(255, 255, 255, 0.04);
+  }
+</style>

--- a/src/components/ReportError.astro
+++ b/src/components/ReportError.astro
@@ -330,12 +330,14 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
     border: 1px solid #fff;
     border-radius: 0;
     color: #fff;
-    font-size: 10px;
+    font-size: 11px;
     white-space: nowrap;
     cursor: pointer;
-    transition: background 0.15s;
+    transition: background 0.15s, color 0.15s;
   }
+  /* invert to an opaque white plate on hover — never go translucent over text */
   .report-float:hover {
-    background: rgba(255, 255, 255, 0.12);
+    background: #fff;
+    color: #000;
   }
 </style>

--- a/src/components/ReportError.astro
+++ b/src/components/ReportError.astro
@@ -34,7 +34,7 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
       placeholder="Что нужно поправить?"></textarea>
 
     <input type="hidden" name="access_key" value={ACCESS_KEY} />
-    <input type="hidden" name="subject" value="Отчёт об ошибке — мыш блог" />
+    <input type="hidden" name="subject" value="Отчет об ошибке — мыш блог" />
     <input type="hidden" name="from_name" value="мыш блог" />
     <input type="hidden" name="quote" class="report-quote-input" />
     <input type="hidden" name="page" value={page} />
@@ -123,7 +123,7 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
       closeForm();
       form.reset();
       setQuote('');
-      setStatus('ok', 'Отчёт отправлен. Спасибо!');
+      setStatus('ok', 'Отчет отправлен. Спасибо!');
     } catch {
       // Relay down / rejected: fall back to the already-public Telegram.
       setStatus(

--- a/src/components/ReportError.astro
+++ b/src/components/ReportError.astro
@@ -1,0 +1,133 @@
+---
+// End-of-post "found a mistake?" affordance: a quiet toggle that reveals an
+// inline report form (textarea + submit). This step builds the markup and the
+// open/close behaviour only — the form is not wired to a relay yet (later step),
+// and the select-text trigger that prefills it is added separately. Kept out of
+// the Pagefind index via data-pagefind-ignore so it never appears in search.
+const page = new URL(Astro.url.pathname, Astro.site).href;
+---
+
+<section class="report" data-pagefind-ignore>
+  <button class="report-toggle mono" type="button" aria-expanded="false" aria-controls="report-form">
+    Нашли ошибку?
+  </button>
+
+  <form class="report-form" id="report-form" hidden>
+    <p class="report-hint">Опечатка, неточность или битая ссылка — напишите, что не так, и я поправлю.</p>
+    <textarea
+      class="report-text"
+      name="message"
+      rows="3"
+      required
+      placeholder="Что нужно поправить?"></textarea>
+    <input type="hidden" name="page" value={page} />
+    <div class="report-actions">
+      <button class="report-cancel mono" type="button">Отмена</button>
+      <button class="report-submit mono" type="submit">Отправить</button>
+    </div>
+  </form>
+</section>
+
+<script>
+  // Toggle the inline report form. Submission is wired to a relay in a later
+  // step; for now the submit is intercepted so the page doesn't navigate.
+  const root = document.querySelector<HTMLElement>('.report');
+  const toggle = root?.querySelector<HTMLButtonElement>('.report-toggle');
+  const form = root?.querySelector<HTMLFormElement>('.report-form');
+  const cancel = root?.querySelector<HTMLButtonElement>('.report-cancel');
+  const textarea = root?.querySelector<HTMLTextAreaElement>('.report-text');
+
+  function setOpen(open: boolean) {
+    if (!form || !toggle) return;
+    form.hidden = !open;
+    toggle.setAttribute('aria-expanded', String(open));
+    if (open) textarea?.focus();
+  }
+
+  toggle?.addEventListener('click', () => setOpen(form?.hidden !== false));
+  cancel?.addEventListener('click', () => setOpen(false));
+  form?.addEventListener('submit', (e) => e.preventDefault());
+</script>
+
+<style>
+  .report {
+    margin-top: 40px;
+    padding-top: 22px;
+    border-top: 1px solid var(--line);
+  }
+
+  .report-toggle {
+    display: inline-flex;
+    align-items: center;
+    padding: 0;
+    background: none;
+    border: 0;
+    font-size: 11px;
+    color: var(--fg-faint);
+    cursor: pointer;
+    transition: color 0.15s;
+  }
+  .report-toggle:hover,
+  .report-toggle[aria-expanded='true'] {
+    color: #fff;
+  }
+
+  .report-form {
+    margin-top: 16px;
+  }
+  .report-hint {
+    margin: 0 0 12px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--fg-dim);
+  }
+  .report-text {
+    display: block;
+    width: 100%;
+    padding: 11px 13px;
+    background: var(--hover);
+    border: 1px solid var(--line);
+    border-radius: 0;
+    color: var(--fg-body);
+    font-family: var(--font-body);
+    font-size: 15px;
+    line-height: 1.5;
+    resize: vertical;
+  }
+  .report-text:focus {
+    outline: none;
+    border-color: var(--line-strong);
+    color: #fff;
+  }
+  .report-text::placeholder {
+    color: var(--fg-faint);
+  }
+
+  .report-actions {
+    display: flex;
+    gap: 12px;
+    margin-top: 12px;
+  }
+  .report-cancel,
+  .report-submit {
+    padding: 9px 16px;
+    font-size: 11px;
+    border: 1px solid var(--line);
+    border-radius: 0;
+    background: none;
+    color: var(--fg-dim);
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s, border-color 0.15s;
+  }
+  .report-cancel:hover {
+    color: #fff;
+    border-color: var(--line-strong);
+  }
+  .report-submit {
+    border-color: #fff;
+    color: #fff;
+  }
+  .report-submit:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+</style>

--- a/src/components/ReportError.astro
+++ b/src/components/ReportError.astro
@@ -1,17 +1,20 @@
 ---
-// End-of-post "found a mistake?" affordance + a select-text trigger.
+// End-of-post "found a mistake?" affordance + a select-text trigger, wired to
+// Web3Forms (a no-backend relay) → a dedicated alias the author monitors.
 //
-//  - The always-works path: an end-of-post `Нашли ошибку?` toggle that reveals
-//    an inline report form (textarea + submit). Submit is not wired to a relay
-//    yet (later step) — it's intercepted so the page doesn't navigate.
-//  - The high-intent path: selecting text inside `.prose` pops a small floating
-//    `Сообщить об ошибке` button near the selection; clicking it opens the same
-//    form, scrolls to it, and prefills the quoted selection. The selection is
-//    the report, so the user only adds (optionally) a note.
+//  - The always-works path: an end-of-post `Нашли ошибку?` toggle reveals an
+//    inline report form (optional note). Submits over fetch, so the reader
+//    stays on the page; on success the form collapses to a thank-you, on
+//    failure it points at the (already-public) Telegram.
+//  - The high-intent path (mouse/trackpad only — see the gate below): selecting
+//    text inside `.prose` pops a floating `Сообщить об ошибке` button; clicking
+//    it opens the same form prefilled with the quoted selection.
 //
-// The whole thing is server-rendered with a hidden `page` field carrying the
-// canonical URL, ready for the relay step. Kept out of the Pagefind index via
-// data-pagefind-ignore so neither button text ever appears in search.
+// The Web3Forms access key is public by design (it ships in client requests
+// regardless), so it lives in the repo like the GA id. Spam is contained by the
+// `botcheck` honeypot + a throwaway alias as the destination. The whole section
+// is data-pagefind-ignore so none of its text lands in search.
+const ACCESS_KEY = '8e12eb37-5ac0-42c5-b8e9-384ee5345607';
 const page = new URL(Astro.url.pathname, Astro.site).href;
 ---
 
@@ -23,44 +26,70 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
   <form class="report-form" id="report-form" hidden>
     <p class="report-hint">Опечатка, неточность или битая ссылка — напишите, что не так, и я поправлю.</p>
     <blockquote class="report-quote" hidden></blockquote>
-    <input type="hidden" name="quote" class="report-quote-input" />
     <textarea
       class="report-text"
       name="message"
       rows="3"
       required
       placeholder="Что нужно поправить?"></textarea>
+
+    <input type="hidden" name="access_key" value={ACCESS_KEY} />
+    <input type="hidden" name="subject" value="Отчёт об ошибке — мыш блог" />
+    <input type="hidden" name="from_name" value="мыш блог" />
+    <input type="hidden" name="quote" class="report-quote-input" />
     <input type="hidden" name="page" value={page} />
+    <!-- Honeypot: invisible to people; bots that tick it are dropped by Web3Forms. -->
+    <input type="checkbox" name="botcheck" class="report-bot" tabindex="-1" autocomplete="off" aria-hidden="true" />
+
     <div class="report-actions">
       <button class="report-cancel mono" type="button">Отмена</button>
       <button class="report-submit mono" type="submit">Отправить</button>
     </div>
   </form>
 
+  <p class="report-status" role="status" hidden></p>
+
   <button class="report-float mono" type="button" hidden>Сообщить об ошибке</button>
 </section>
 
 <script>
+  const ENDPOINT = 'https://api.web3forms.com/submit';
+
   const root = document.querySelector<HTMLElement>('.report');
   const toggle = root?.querySelector<HTMLButtonElement>('.report-toggle');
   const form = root?.querySelector<HTMLFormElement>('.report-form');
   const cancel = root?.querySelector<HTMLButtonElement>('.report-cancel');
+  const submit = root?.querySelector<HTMLButtonElement>('.report-submit');
   const textarea = root?.querySelector<HTMLTextAreaElement>('.report-text');
   const quoteBox = root?.querySelector<HTMLElement>('.report-quote');
   const quoteInput = root?.querySelector<HTMLInputElement>('.report-quote-input');
+  const status = root?.querySelector<HTMLElement>('.report-status');
   const float = root?.querySelector<HTMLButtonElement>('.report-float');
   const prose = document.querySelector<HTMLElement>('.prose');
 
-  // ----- the inline form (open/close + prefill) -----------------------------
+  // ----- the inline form (open/close + prefill + submit) --------------------
   function setQuote(text: string) {
     if (!quoteBox || !quoteInput) return;
     quoteInput.value = text;
     quoteBox.textContent = text ? `«${text}»` : '';
     quoteBox.hidden = !text;
+    if (textarea) textarea.required = !text; // the quote is the report → note optional
+  }
+  function setStatus(kind: 'ok' | 'error', html: string) {
+    if (!status) return;
+    status.dataset.kind = kind;
+    status.innerHTML = html;
+    status.hidden = false;
+  }
+  function clearStatus() {
+    if (!status) return;
+    status.hidden = true;
+    status.textContent = '';
   }
 
   function openForm(center: boolean) {
     if (!form || !toggle) return;
+    clearStatus();
     form.hidden = false;
     toggle.setAttribute('aria-expanded', 'true');
     textarea?.focus({ preventScroll: true });
@@ -75,7 +104,37 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
   // Plain toggle preserves whatever was typed/quoted before (nice on re-open).
   toggle?.addEventListener('click', () => (form?.hidden !== false ? openForm(false) : closeForm()));
   cancel?.addEventListener('click', closeForm);
-  form?.addEventListener('submit', (e) => e.preventDefault()); // relay wired in a later step
+
+  form?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    if (!form || !submit) return;
+    const label = submit.textContent;
+    submit.disabled = true;
+    submit.textContent = 'Отправляю…';
+    clearStatus();
+    try {
+      const res = await fetch(ENDPOINT, {
+        method: 'POST',
+        headers: { Accept: 'application/json' },
+        body: new FormData(form),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) throw new Error(data.message || 'failed');
+      closeForm();
+      form.reset();
+      setQuote('');
+      setStatus('ok', 'Спасибо! Отчёт отправлен — я всё проверю и поправлю.');
+    } catch {
+      // Relay down / rejected: fall back to the already-public Telegram.
+      setStatus(
+        'error',
+        'Не удалось отправить. Напишите в <a href="https://t.me/ml_mouse" target="_blank" rel="noopener">Telegram</a> или попробуйте позже.',
+      );
+    } finally {
+      submit.disabled = false;
+      submit.textContent = label;
+    }
+  });
 
   // ----- the floating select-text trigger (fine-pointer devices only) -------
   // On touch, the OS owns text selection: iOS/Android paint their own callout
@@ -206,6 +265,10 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
   .report-text::placeholder {
     color: var(--fg-faint);
   }
+  /* Honeypot — kept out of sight and out of the tab order. */
+  .report-bot {
+    display: none;
+  }
 
   .report-actions {
     display: flex;
@@ -233,6 +296,25 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
   }
   .report-submit:hover {
     background: rgba(255, 255, 255, 0.08);
+  }
+  .report-submit:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .report-status {
+    margin-top: 16px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--fg-dim);
+  }
+  .report-status[data-kind='error'] {
+    color: var(--fg-body);
+  }
+  .report-status a {
+    color: #fff;
+    text-decoration: underline;
+    text-underline-offset: 3px;
   }
 
   /* Floating trigger: solid black plate + hairline border reads cleanly over

--- a/src/components/ReportError.astro
+++ b/src/components/ReportError.astro
@@ -77,63 +77,70 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
   cancel?.addEventListener('click', closeForm);
   form?.addEventListener('submit', (e) => e.preventDefault()); // relay wired in a later step
 
-  // ----- the floating select-text trigger -----------------------------------
-  // The current valid selection text, kept fresh so the floating button never
-  // has to read the (possibly already-collapsed) selection at click time.
-  let pending = '';
+  // ----- the floating select-text trigger (fine-pointer devices only) -------
+  // On touch, the OS owns text selection: iOS/Android paint their own callout
+  // (Copy / Look Up / Share …) at the selection, composited *above* the web
+  // view — a button placed there can't sit on top of it and just collides, with
+  // no standard way to dodge or suppress it. So the floating trigger is a
+  // mouse/trackpad enhancement; touch users use the end-of-post button instead.
+  if (window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
+    // The current valid selection text, kept fresh so the floating button never
+    // has to read the (possibly already-collapsed) selection at click time.
+    let pending = '';
 
-  function selectionText(): string {
-    const sel = window.getSelection();
-    if (!sel || sel.isCollapsed || sel.rangeCount === 0 || !prose) return '';
-    const range = sel.getRangeAt(0);
-    if (!prose.contains(range.commonAncestorContainer)) return ''; // only inside the post body
-    return sel.toString().trim();
-  }
+    function selectionText(): string {
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed || sel.rangeCount === 0 || !prose) return '';
+      const range = sel.getRangeAt(0);
+      if (!prose.contains(range.commonAncestorContainer)) return ''; // only inside the post body
+      return sel.toString().trim();
+    }
 
-  function placeFloat() {
-    const sel = window.getSelection();
-    if (!float || !sel || sel.rangeCount === 0) return hideFloat();
-    const rect = sel.getRangeAt(0).getBoundingClientRect();
-    if (!rect.width && !rect.height) return hideFloat();
-    float.hidden = false; // make it measurable before positioning
-    const h = float.offsetHeight;
-    const halfW = float.offsetWidth / 2;
-    const top = rect.top > h + 16 ? rect.top - h - 8 : rect.bottom + 8;
-    const left = Math.min(Math.max(rect.left + rect.width / 2, halfW + 6), window.innerWidth - halfW - 6);
-    float.style.top = `${top}px`;
-    float.style.left = `${left}px`;
-  }
-  function hideFloat() {
-    if (float) float.hidden = true;
-  }
+    function placeFloat() {
+      const sel = window.getSelection();
+      if (!float || !sel || sel.rangeCount === 0) return hideFloat();
+      const rect = sel.getRangeAt(0).getBoundingClientRect();
+      if (!rect.width && !rect.height) return hideFloat();
+      float.hidden = false; // make it measurable before positioning
+      const h = float.offsetHeight;
+      const halfW = float.offsetWidth / 2;
+      const top = rect.top > h + 16 ? rect.top - h - 8 : rect.bottom + 8;
+      const left = Math.min(Math.max(rect.left + rect.width / 2, halfW + 6), window.innerWidth - halfW - 6);
+      float.style.top = `${top}px`;
+      float.style.left = `${left}px`;
+    }
+    function hideFloat() {
+      if (float) float.hidden = true;
+    }
 
-  let queued = false;
-  function refresh() {
-    pending = selectionText();
-    pending ? placeFloat() : hideFloat();
-  }
-  document.addEventListener('selectionchange', () => {
-    if (queued) return;
-    queued = true;
-    requestAnimationFrame(() => {
-      queued = false;
-      refresh();
+    let queued = false;
+    function refresh() {
+      pending = selectionText();
+      pending ? placeFloat() : hideFloat();
+    }
+    document.addEventListener('selectionchange', () => {
+      if (queued) return;
+      queued = true;
+      requestAnimationFrame(() => {
+        queued = false;
+        refresh();
+      });
     });
-  });
-  // Keep the button glued to the text as the page scrolls/resizes.
-  addEventListener('scroll', () => float && !float.hidden && refresh(), { passive: true });
-  addEventListener('resize', () => float && !float.hidden && refresh(), { passive: true });
+    // Keep the button glued to the text as the page scrolls/resizes.
+    addEventListener('scroll', () => float && !float.hidden && refresh(), { passive: true });
+    addEventListener('resize', () => float && !float.hidden && refresh(), { passive: true });
 
-  // pointerdown + preventDefault keeps the click from collapsing the selection
-  // and stealing focus before we act on the stored `pending` text.
-  float?.addEventListener('pointerdown', (e) => {
-    e.preventDefault();
-    if (!pending) return;
-    setQuote(pending);
-    hideFloat();
-    window.getSelection()?.removeAllRanges();
-    openForm(true);
-  });
+    // pointerdown + preventDefault keeps the click from collapsing the selection
+    // and stealing focus before we act on the stored `pending` text.
+    float?.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      if (!pending) return;
+      setQuote(pending);
+      hideFloat();
+      window.getSelection()?.removeAllRanges();
+      openForm(true);
+    });
+  }
 </script>
 
 <style>

--- a/src/components/ReportError.astro
+++ b/src/components/ReportError.astro
@@ -1,9 +1,17 @@
 ---
-// End-of-post "found a mistake?" affordance: a quiet toggle that reveals an
-// inline report form (textarea + submit). This step builds the markup and the
-// open/close behaviour only — the form is not wired to a relay yet (later step),
-// and the select-text trigger that prefills it is added separately. Kept out of
-// the Pagefind index via data-pagefind-ignore so it never appears in search.
+// End-of-post "found a mistake?" affordance + a select-text trigger.
+//
+//  - The always-works path: an end-of-post `Нашли ошибку?` toggle that reveals
+//    an inline report form (textarea + submit). Submit is not wired to a relay
+//    yet (later step) — it's intercepted so the page doesn't navigate.
+//  - The high-intent path: selecting text inside `.prose` pops a small floating
+//    `Сообщить об ошибке` button near the selection; clicking it opens the same
+//    form, scrolls to it, and prefills the quoted selection. The selection is
+//    the report, so the user only adds (optionally) a note.
+//
+// The whole thing is server-rendered with a hidden `page` field carrying the
+// canonical URL, ready for the relay step. Kept out of the Pagefind index via
+// data-pagefind-ignore so neither button text ever appears in search.
 const page = new URL(Astro.url.pathname, Astro.site).href;
 ---
 
@@ -14,6 +22,8 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
 
   <form class="report-form" id="report-form" hidden>
     <p class="report-hint">Опечатка, неточность или битая ссылка — напишите, что не так, и я поправлю.</p>
+    <blockquote class="report-quote" hidden></blockquote>
+    <input type="hidden" name="quote" class="report-quote-input" />
     <textarea
       class="report-text"
       name="message"
@@ -26,27 +36,104 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
       <button class="report-submit mono" type="submit">Отправить</button>
     </div>
   </form>
+
+  <button class="report-float mono" type="button" hidden>Сообщить об ошибке</button>
 </section>
 
 <script>
-  // Toggle the inline report form. Submission is wired to a relay in a later
-  // step; for now the submit is intercepted so the page doesn't navigate.
   const root = document.querySelector<HTMLElement>('.report');
   const toggle = root?.querySelector<HTMLButtonElement>('.report-toggle');
   const form = root?.querySelector<HTMLFormElement>('.report-form');
   const cancel = root?.querySelector<HTMLButtonElement>('.report-cancel');
   const textarea = root?.querySelector<HTMLTextAreaElement>('.report-text');
+  const quoteBox = root?.querySelector<HTMLElement>('.report-quote');
+  const quoteInput = root?.querySelector<HTMLInputElement>('.report-quote-input');
+  const float = root?.querySelector<HTMLButtonElement>('.report-float');
+  const prose = document.querySelector<HTMLElement>('.prose');
 
-  function setOpen(open: boolean) {
-    if (!form || !toggle) return;
-    form.hidden = !open;
-    toggle.setAttribute('aria-expanded', String(open));
-    if (open) textarea?.focus();
+  // ----- the inline form (open/close + prefill) -----------------------------
+  function setQuote(text: string) {
+    if (!quoteBox || !quoteInput) return;
+    quoteInput.value = text;
+    quoteBox.textContent = text ? `«${text}»` : '';
+    quoteBox.hidden = !text;
   }
 
-  toggle?.addEventListener('click', () => setOpen(form?.hidden !== false));
-  cancel?.addEventListener('click', () => setOpen(false));
-  form?.addEventListener('submit', (e) => e.preventDefault());
+  function openForm(center: boolean) {
+    if (!form || !toggle) return;
+    form.hidden = false;
+    toggle.setAttribute('aria-expanded', 'true');
+    textarea?.focus({ preventScroll: true });
+    form.scrollIntoView({ behavior: 'smooth', block: center ? 'center' : 'nearest' });
+  }
+  function closeForm() {
+    if (!form || !toggle) return;
+    form.hidden = true;
+    toggle.setAttribute('aria-expanded', 'false');
+  }
+
+  // Plain toggle preserves whatever was typed/quoted before (nice on re-open).
+  toggle?.addEventListener('click', () => (form?.hidden !== false ? openForm(false) : closeForm()));
+  cancel?.addEventListener('click', closeForm);
+  form?.addEventListener('submit', (e) => e.preventDefault()); // relay wired in a later step
+
+  // ----- the floating select-text trigger -----------------------------------
+  // The current valid selection text, kept fresh so the floating button never
+  // has to read the (possibly already-collapsed) selection at click time.
+  let pending = '';
+
+  function selectionText(): string {
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed || sel.rangeCount === 0 || !prose) return '';
+    const range = sel.getRangeAt(0);
+    if (!prose.contains(range.commonAncestorContainer)) return ''; // only inside the post body
+    return sel.toString().trim();
+  }
+
+  function placeFloat() {
+    const sel = window.getSelection();
+    if (!float || !sel || sel.rangeCount === 0) return hideFloat();
+    const rect = sel.getRangeAt(0).getBoundingClientRect();
+    if (!rect.width && !rect.height) return hideFloat();
+    float.hidden = false; // make it measurable before positioning
+    const h = float.offsetHeight;
+    const halfW = float.offsetWidth / 2;
+    const top = rect.top > h + 16 ? rect.top - h - 8 : rect.bottom + 8;
+    const left = Math.min(Math.max(rect.left + rect.width / 2, halfW + 6), window.innerWidth - halfW - 6);
+    float.style.top = `${top}px`;
+    float.style.left = `${left}px`;
+  }
+  function hideFloat() {
+    if (float) float.hidden = true;
+  }
+
+  let queued = false;
+  function refresh() {
+    pending = selectionText();
+    pending ? placeFloat() : hideFloat();
+  }
+  document.addEventListener('selectionchange', () => {
+    if (queued) return;
+    queued = true;
+    requestAnimationFrame(() => {
+      queued = false;
+      refresh();
+    });
+  });
+  // Keep the button glued to the text as the page scrolls/resizes.
+  addEventListener('scroll', () => float && !float.hidden && refresh(), { passive: true });
+  addEventListener('resize', () => float && !float.hidden && refresh(), { passive: true });
+
+  // pointerdown + preventDefault keeps the click from collapsing the selection
+  // and stealing focus before we act on the stored `pending` text.
+  float?.addEventListener('pointerdown', (e) => {
+    e.preventDefault();
+    if (!pending) return;
+    setQuote(pending);
+    hideFloat();
+    window.getSelection()?.removeAllRanges();
+    openForm(true);
+  });
 </script>
 
 <style>
@@ -80,6 +167,16 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
     font-size: 13px;
     line-height: 1.5;
     color: var(--fg-dim);
+  }
+  .report-quote {
+    margin: 0 0 12px;
+    padding: 9px 13px;
+    border-left: 2px solid var(--line-strong);
+    background: var(--hover);
+    color: var(--fg-dim);
+    font-size: 14px;
+    font-style: normal;
+    line-height: 1.5;
   }
   .report-text {
     display: block;
@@ -129,5 +226,25 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
   }
   .report-submit:hover {
     background: rgba(255, 255, 255, 0.08);
+  }
+
+  /* Floating trigger: solid black plate + hairline border reads cleanly over
+     body text without a shadow (on-brand). Positioned in JS (viewport coords). */
+  .report-float {
+    position: fixed;
+    z-index: 60;
+    transform: translateX(-50%);
+    padding: 7px 11px;
+    background: #000;
+    border: 1px solid #fff;
+    border-radius: 0;
+    color: #fff;
+    font-size: 10px;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .report-float:hover {
+    background: rgba(255, 255, 255, 0.12);
   }
 </style>

--- a/src/components/ReportError.astro
+++ b/src/components/ReportError.astro
@@ -123,7 +123,7 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
       closeForm();
       form.reset();
       setQuote('');
-      setStatus('ok', 'Спасибо! Отчёт отправлен — я всё проверю и поправлю.');
+      setStatus('ok', 'Отчёт отправлен. Спасибо!');
     } catch {
       // Relay down / rejected: fall back to the already-public Telegram.
       setStatus(
@@ -203,12 +203,6 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
 </script>
 
 <style>
-  .report {
-    margin-top: 40px;
-    padding-top: 22px;
-    border-top: 1px solid var(--line);
-  }
-
   .report-toggle {
     display: inline-flex;
     align-items: center;
@@ -240,7 +234,7 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
     border-left: 2px solid var(--line-strong);
     background: var(--hover);
     color: var(--fg-dim);
-    font-size: 14px;
+    font-size: 13px;
     font-style: normal;
     line-height: 1.5;
   }
@@ -304,11 +298,19 @@ const page = new URL(Astro.url.pathname, Astro.site).href;
 
   .report-status {
     margin-top: 16px;
-    font-size: 13px;
     line-height: 1.5;
-    color: var(--fg-dim);
   }
+  /* success → the same 11px mono kicker as the helpful confirmation */
+  .report-status[data-kind='ok'] {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--fg-faint);
+  }
+  /* error → readable prose, since it carries the Telegram link */
   .report-status[data-kind='error'] {
+    font-size: 13px;
     color: var(--fg-body);
   }
   .report-status a {

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -300,16 +300,18 @@ for (const h of headings as Heading[]) {
     display: grid;
     grid-template-columns: 1fr 1fr;
     margin-top: 54px;
-    border-top: 1px solid var(--line);
-    border-left: 1px solid var(--line);
+    border: 1px solid var(--line);
   }
   .pn {
     padding: 18px;
-    border-right: 1px solid var(--line);
-    border-bottom: 1px solid var(--line);
     text-decoration: none;
     color: #fff;
     transition: background 0.15s;
+  }
+  /* middle divider only when both cells exist — otherwise the box stays a clean
+     rectangle with one empty half (fixes the open bottom-left on first/last posts) */
+  .pn:first-child:not(:only-child) {
+    border-right: 1px solid var(--line);
   }
   .pn:hover {
     background: var(--hover);

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -70,7 +70,10 @@ for (const h of headings as Heading[]) {
       <div class="col">
         <div class="prose"><slot /></div>
 
-        <HelpfulVote postId={post.id} />
+        <div class="feedback" data-pagefind-ignore>
+          <HelpfulVote postId={post.id} />
+          <ReportError />
+        </div>
 
         <nav class="prevnext" data-pagefind-ignore>
           {
@@ -90,8 +93,6 @@ for (const h of headings as Heading[]) {
             )
           }
         </nav>
-
-        <ReportError />
       </div>
 
       {
@@ -282,6 +283,16 @@ for (const h of headings as Heading[]) {
   .col {
     max-width: 740px;
     min-width: 0;
+  }
+
+  /* post-feedback block: the helpful vote + error report under one top rule */
+  .feedback {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    margin-top: 54px;
+    padding-top: 26px;
+    border-top: 1px solid var(--line);
   }
 
   /* prev / next */

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -1,5 +1,6 @@
 ---
 import Base from './Base.astro';
+import ReportError from '../components/ReportError.astro';
 import { url } from '../lib/base';
 import { formatDate } from '../lib/date';
 import 'katex/dist/katex.min.css';
@@ -86,6 +87,8 @@ for (const h of headings as Heading[]) {
             )
           }
         </nav>
+
+        <ReportError />
       </div>
 
       {

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -1,6 +1,7 @@
 ---
 import Base from './Base.astro';
 import ReportError from '../components/ReportError.astro';
+import HelpfulVote from '../components/HelpfulVote.astro';
 import { url } from '../lib/base';
 import { formatDate } from '../lib/date';
 import 'katex/dist/katex.min.css';
@@ -68,6 +69,8 @@ for (const h of headings as Heading[]) {
     <div class="layout">
       <div class="col">
         <div class="prose"><slot /></div>
+
+        <HelpfulVote postId={post.id} />
 
         <nav class="prevnext" data-pagefind-ignore>
           {


### PR DESCRIPTION
## Why
Readers frequently spot typos but almost never report them — the only path was a reporting line buried in the repo README, which means switching apps and (for most) creating a GitHub account. This adds a near-zero-friction, in-page way to report mistakes, plus a lightweight private feedback signal. Everything stays compatible with the static GitHub Pages deploy — **no backend**.

## What's in it
**Error reporting (the main feature)**
- End-of-post **Нашли ошибку?** toggle that opens an inline form — the always-works path on every device.
- On desktop/trackpad, selecting text in a post pops a floating **Сообщить об ошибке** button that opens the same form prefilled with the quoted selection. Gated to fine-pointer devices: on touch the OS draws its own selection callout *above* the page, so the floating button is suppressed and touch users fall back to the toggle.
- Submits over `fetch` to **Web3Forms** (a no-backend relay) → a dedicated throwaway alias the author monitors. The reader stays on the page: success collapses to a thank-you; a failed/blocked send points at the already-public Telegram.
- Spam contained by a `botcheck` honeypot. The Web3Forms access key is **public by design** (it ships in client requests regardless), so it lives in the source like the existing GA id.

**Private helpful-vote**
- A `Полезно? Да / Нет` row that fires a GA event (`helpful`, with `post_id` + `rating`) — no visible counter, so it's feedback for the author, not social proof. Degrades silently when gtag is absent (dev / ad-block).

**README**
- The reporting line now leads with the in-page path, keeping Telegram + Issue/PR for contributors.

## Notes
- All of this chrome carries `data-pagefind-ignore`, so none of its text pollutes the search index.
- The two affordances are grouped under one rule before prev/next; the feedback UI uses a tight 11 / 13 / 15px type scale.

## Testing
- `astro check` + `bun run build` clean.
- Author-verified live in the browser: a real report lands in Web3Forms (formatted email received), the honeypot rejects, the Telegram fallback link is correct.
- Footer states (grouping, prev/next box on first/last + middle posts, float hover, vote confirmation) verified via headless-Chrome screenshots on desktop; the toggle path checked on iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)