### PR TITLE
Search: land results on the matching section, and clean up the index

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,7 @@ import rehypeKatex from 'rehype-katex';
 import { pluginOutputBlocks } from './src/lib/ec-output.mjs';
 import { rehypeFigures } from './src/lib/rehype-figures.mjs';
 import { rehypeLinks } from './src/lib/rehype-links.mjs';
+import { rehypePagefindIgnore, pluginPagefindIgnore } from './src/lib/pagefind-ignore.mjs';
 
 // Localize the code-block copy button (Expressive Code defaults to en-US).
 pluginFramesTexts.overrideTexts('en', {
@@ -25,13 +26,14 @@ export default defineConfig({
   // KaTeX CSS is loaded by the layout; KaTeX inherits currentColor (white on black).
   markdown: {
     remarkPlugins: [remarkMath],
-    rehypePlugins: [rehypeKatex, rehypeFigures, rehypeLinks],
+    // rehypePagefindIgnore must follow rehypeKatex so the .katex output exists.
+    rehypePlugins: [rehypeKatex, rehypePagefindIgnore, rehypeFigures, rehypeLinks],
   },
   integrations: [
     // Code blocks: titles, line highlighting, copy button. Dark-only, brutalist —
     // square corners, hairline borders, no shadow, mono UI. Refined in the design phase.
     expressiveCode({
-      plugins: [pluginOutputBlocks()],
+      plugins: [pluginOutputBlocks(), pluginPagefindIgnore()],
       themes: ['github-dark'],
       styleOverrides: {
         borderRadius: '0',

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -156,9 +156,16 @@
     markActive();
     resultsEl?.querySelector('.active')?.scrollIntoView({ block: 'nearest' });
   }
+  // Activating a result must close the palette first — otherwise a result on the
+  // current page (same path, only the #section differs) navigates without an
+  // unload, leaving the palette open and the body scroll-locked over the page.
+  function activate(href: string) {
+    close();
+    location.href = href;
+  }
   function go() {
     const r = rows[sel];
-    if (r) location.href = resolveUrl(r.url);
+    if (r) activate(resolveUrl(r.url));
   }
 
   input?.addEventListener('input', () => {
@@ -189,6 +196,16 @@
 
   document.querySelectorAll('[data-search-trigger]').forEach((b) => b.addEventListener('click', open));
   document.querySelector('[data-search-close]')?.addEventListener('click', close);
+
+  // Plain clicks on a result close the palette, then navigate/scroll; modifier
+  // and middle clicks fall through so "open in new tab" still works.
+  resultsEl?.addEventListener('click', (e) => {
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    const a = (e.target as HTMLElement).closest('a.row') as HTMLAnchorElement | null;
+    if (!a) return;
+    e.preventDefault();
+    activate(a.href);
+  });
 </script>
 
 <style>

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -36,8 +36,10 @@
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let pf: any = null;
   let results: any[] = [];
+  let rows: any[] = []; // flat list of navigable rows (post headers + section rows)
   let sel = 0;
   let debounce: number | undefined;
+  const MAX_SECTIONS = 3; // matching sections shown per post before "+N more"
 
   async function ensurePf() {
     if (pf) return pf;
@@ -76,10 +78,18 @@
     render();
   }
 
+  function markActive() {
+    resultsEl?.querySelectorAll<HTMLElement>('.row').forEach((n) => {
+      n.classList.toggle('active', Number(n.dataset.idx) === sel);
+    });
+  }
+
   function render() {
     if (!resultsEl || !countEl) return;
     const q = input?.value.trim() ?? '';
+    // The badge counts matching posts, not the section rows beneath them.
     countEl.textContent = q && results.length ? String(results.length).padStart(2, '0') : '';
+    rows = [];
     if (!q) {
       resultsEl.innerHTML = '';
       return;
@@ -88,14 +98,43 @@
       resultsEl.innerHTML = '<div class="empty mono">ничего не найдено</div>';
       return;
     }
+    // One group per post: a header row linking to the top of the post, then its
+    // matching sections as indented rows linking to #heading. Pagefind splits a
+    // page into sub_results on headings (those with anchors); the anchor-less
+    // root sub_result is the pre-heading intro. To avoid repeating text, the
+    // header only carries an excerpt when the post has no matching section.
     resultsEl.innerHTML = results
-      .map(
-        (r, i) =>
-          `<a class="result${i === sel ? ' active' : ''}" href="${resolveUrl(r.url)}">` +
-          `<div class="r-title">${r.meta?.title ?? ''}</div>` +
-          `<div class="r-excerpt">${r.excerpt ?? ''}</div></a>`,
-      )
+      .map((r) => {
+        const subs = Array.isArray(r.sub_results) ? r.sub_results : [];
+        const sections = subs.filter((s: any) => typeof s.url === 'string' && s.url.includes('#'));
+        const intro = subs.find((s: any) => typeof s.url === 'string' && !s.url.includes('#'));
+        const headExcerpt = sections.length ? '' : (intro?.excerpt ?? r.excerpt ?? '');
+
+        const headIdx = rows.length;
+        rows.push({ url: r.url });
+        let out =
+          `<a class="row g-post" data-idx="${headIdx}" href="${resolveUrl(r.url)}">` +
+          `<span class="g-title">${r.meta?.title ?? ''}</span>` +
+          (headExcerpt ? `<span class="g-excerpt">${headExcerpt}</span>` : '') +
+          `</a>`;
+
+        for (const s of sections.slice(0, MAX_SECTIONS)) {
+          const idx = rows.length;
+          rows.push({ url: s.url });
+          out +=
+            `<a class="row result" data-idx="${idx}" href="${resolveUrl(s.url)}">` +
+            `<span class="r-section">${s.title ?? ''}</span>` +
+            (s.excerpt ? `<span class="r-excerpt">${s.excerpt}</span>` : '') +
+            `</a>`;
+        }
+        const more = sections.length - Math.min(sections.length, MAX_SECTIONS);
+        if (more > 0) out += `<div class="more mono">+${more} ещё в этой статье</div>`;
+        return `<div class="group">${out}</div>`;
+      })
       .join('');
+
+    if (sel >= rows.length) sel = 0;
+    markActive();
   }
 
   async function runSearch(q: string) {
@@ -112,13 +151,13 @@
   }
 
   function move(d: number) {
-    if (!results.length) return;
-    sel = (sel + d + results.length) % results.length;
-    render();
-    resultsEl?.querySelector('.result.active')?.scrollIntoView({ block: 'nearest' });
+    if (!rows.length) return;
+    sel = (sel + d + rows.length) % rows.length;
+    markActive();
+    resultsEl?.querySelector('.active')?.scrollIntoView({ block: 'nearest' });
   }
   function go() {
-    const r = results[sel];
+    const r = rows[sel];
     if (r) location.href = resolveUrl(r.url);
   }
 
@@ -231,31 +270,66 @@
     overflow-y: auto;
     flex: 1;
   }
-  .results :global(.result) {
+  /* One group per post: a bold post-title header row, then indented section
+     rows (mirrors the nested TOC). Both row types share .row for selection. */
+  .results :global(.group) {
+    padding: 5px 0;
+  }
+  .results :global(.group + .group) {
+    border-top: 1px solid var(--line);
+  }
+  .results :global(.row) {
     display: block;
-    padding: 13px 18px;
     border-left: 2px solid transparent;
     text-decoration: none;
     color: inherit;
   }
-  .results :global(.result.active) {
+  .results :global(.row.active) {
     background: rgba(255, 255, 255, 0.08);
     border-left-color: var(--accent);
   }
-  .results :global(.r-title) {
+  .results :global(.g-post) {
+    padding: 9px 18px 7px;
+  }
+  .results :global(.g-title) {
+    display: block;
     font-family: var(--font-display);
     font-weight: 700;
     font-size: 15.5px;
     line-height: 1.2;
     color: #fff;
   }
-  .results :global(.r-excerpt) {
-    margin-top: 4px;
-    font-size: 13px;
+  .results :global(.g-excerpt) {
+    display: block;
+    margin-top: 3px;
+    font-size: 12.5px;
     line-height: 1.45;
     color: var(--fg-dim);
   }
-  .results :global(.r-excerpt mark) {
+  .results :global(.result) {
+    padding: 7px 18px 7px 34px;
+  }
+  .results :global(.r-section) {
+    display: block;
+    font-size: 13.5px;
+    font-weight: 600;
+    line-height: 1.25;
+    color: rgba(255, 255, 255, 0.9);
+  }
+  .results :global(.r-excerpt) {
+    display: block;
+    margin-top: 2px;
+    font-size: 12.5px;
+    line-height: 1.45;
+    color: var(--fg-dim);
+  }
+  .results :global(.more) {
+    padding: 3px 18px 8px 34px;
+    font-size: 10.5px;
+    letter-spacing: 0.06em;
+    color: var(--fg-faint);
+  }
+  .results :global(mark) {
     background: none;
     color: #fff;
     font-weight: 600;

--- a/src/lib/pagefind-ignore.mjs
+++ b/src/lib/pagefind-ignore.mjs
@@ -1,0 +1,41 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * Keep code blocks and math out of the Pagefind search index, so results match
+ * only prose (inline `code` stays — it's part of the sentence). `data-pagefind-
+ * ignore` tells Pagefind to skip an element's subtree.
+ *
+ * Two halves, because code and math are emitted by different pipelines:
+ *   - math (KaTeX, via rehype-katex) is tagged in the markdown rehype pass;
+ *   - code (Expressive Code) is tagged inside EC's own render hook — the
+ *     pipeline that owns the code block's final markup — rather than guessing at
+ *     rehype-plugin ordering around EC.
+ */
+
+// rehype: tag KaTeX output — display (`.katex-display`) and inline (`.katex`).
+export function rehypePagefindIgnore() {
+  return (tree) => {
+    visit(tree, 'element', (node) => {
+      const cls = node.properties?.className;
+      const classes = Array.isArray(cls) ? cls : cls ? [cls] : [];
+      if (classes.includes('katex') || classes.includes('katex-display')) {
+        node.properties.dataPagefindIgnore = true;
+      }
+    });
+  };
+}
+
+// Expressive Code: tag each rendered code block at its root (covers the code,
+// its frame, and the title/filename header).
+export function pluginPagefindIgnore() {
+  return {
+    name: 'pagefind-ignore',
+    hooks: {
+      postprocessRenderedBlock(context) {
+        const root = context.renderData.blockAst;
+        root.properties = root.properties || {};
+        root.properties.dataPagefindIgnore = true;
+      },
+    },
+  };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,6 +27,11 @@
 html {
   scroll-behavior: smooth;
 }
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
 
 body {
   margin: 0;


### PR DESCRIPTION
## Why

Search matched anywhere in a post but only ever linked to the **top** of the post — so after clicking, you had to hunt for the term with the browser's own find. It also indexed code blocks and equations, which surfaced junk hits (`for`, `range`, `import`, lone math variables like `w`/`x`).

This reworks search to land you on the **matching section**, and cleans up what gets indexed — all by leaning on Pagefind's native sub-results, with **no new dependencies and no custom index**.

## What changed

- **Exclude code blocks and equations from the index** (`1676fe6`). A small `pagefind-ignore` helper tags KaTeX (`.katex`) in the rehype pass and each Expressive Code block via EC's own render hook, so search now matches prose (and inline `` `code` ``, kept on purpose). The junk-term hits are gone.
- **Group results into matching sections** (`236bd41`). Each post renders as a group: a title header → the post top, then its matching sections as indented rows → `#heading`, capped at 3 with a "+N more" tail. The badge counts posts; keyboard ↑/↓ walks every row. Built on Pagefind's heading sub-results.
- **Instant anchor scroll for reduced-motion users** (`e1ba1fb`). `prefers-reduced-motion` drops the global smooth scroll to an instant jump for all anchor nav (TOC + search).
- **Close the palette when a result is activated** (`0cadb52`). A result on the *current* post (same path, only the `#section` differs) used to navigate without unloading, leaving the palette open and the body scroll-locked. It now closes (restoring scroll) then navigates; modifier/middle clicks still open in a new tab.

## Notes / decisions

- An arrival-highlight on the landed heading was built and then **dropped**: its left-bar collided with the heading text, and the flash burned out during the smooth scroll (only visible on hard refresh). Landing the heading at the top of the viewport is a sufficient cue. Only its reduced-motion scroll fix was kept.
- Paragraph-level landing was considered and rejected — section-level matches the actual recall pattern (you want the section start to refresh context; the excerpt gives pinpoint context; Ctrl+F covers the exact word).
- Search stays **global on every page** (including post pages) — it serves cross-post recall from anywhere, and the close fix resolves the "feels off on a post page" issue without page-scoping.

## Verification

- Typecheck + build clean.
- Confirmed in the built output: 276/276 code figures and all KaTeX roots carry `data-pagefind-ignore`; code-only syntax (`import torch`, `def `, `print(`) is gone from the index while inline-code prose mentions stay; all 74 headings carry `id`s and the Pagefind index records their anchors (what sub-results are built from).
- Checked live in preview: grouped section results, code/math junk gone, and same-page result clicks now close the palette and scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)